### PR TITLE
Fixed TypeError that crashes the addon

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -144,7 +144,7 @@ def __format_videos(videos):
             'count': i,
             'plot': '[CR]'.join((
                 'Date: %s' % video['date'],
-                'Size: %d MB' % (video['streams'][quality]['size'] / 1048576),
+                'Size: %d MB' % (int(video['streams'][quality]['size']) / 1048576),
                 'Length: %s' % video['duration_str'],
             )),
         },


### PR DESCRIPTION
The latest Version of the Addon crashes every time you try to get any videodata. This change prevents the addon from crashing.
I guess the 4Players api changed and returns other types.

Kodi.log callstack for further information:
"
ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.TypeError'>
                                            Error Contents: unsupported operand type(s) for /: 'unicode' and 'int'
                                            Traceback (most recent call last):
                                              File "C:\Users\...\AppData\Roaming\Kodi\addons\plugin.video.4players\addon.py", line 210, in <module>
                                                plugin.run()
                                              File "C:\Users\...\AppData\Roaming\Kodi\addons\script.module.xbmcswift2\lib\xbmcswift2\plugin.py", line 332, in run
                                                items = self._dispatch(self.request.path)
                                              File "C:\Users\...\AppData\Roaming\Kodi\addons\script.module.xbmcswift2\lib\xbmcswift2\plugin.py", line 306, in _dispatch
                                                listitems = view_func(**items)
                                              File "C:\Users\...\AppData\Roaming\Kodi\addons\plugin.video.4players\addon.py", line 65, in latest_videos
                                                items = __format_videos(videos)
                                              File "C:\Users\...\AppData\Roaming\Kodi\addons\plugin.video.4players\addon.py", line 166, in __format_videos
                                                } for i, video in enumerate(videos)]
                                            TypeError: unsupported operand type(s) for /: 'unicode' and 'int'
                                            -->End of Python script error report<--
"